### PR TITLE
updated endpoints for cookie saving

### DIFF
--- a/src/controllers/user.rs
+++ b/src/controllers/user.rs
@@ -56,16 +56,19 @@ pub async fn register_user(payload: Json<RegisterUser>, pool: Data<PgPool>) -> i
 
     let cookie = Cookie::build("OKIJ", &token)
         .http_only(true)
-        // .same_site(SameSite::Strict)
+        .same_site(SameSite::None)
+        .secure(true)
         .path("/")
         .max_age(Duration::hours(2))
         .finish();
 
-    HttpResponse::Ok().cookie(cookie).json(ApiResponse {
-        status: 200,
-        msg: String::from("User registered & token generated"),
-        results: Some(token),
-    })
+    HttpResponse::Ok()
+        .cookie(cookie)
+        .json(ApiResponse::<String> {
+            status: 200,
+            msg: String::from("User registered & token generated"),
+            results: None,
+        })
 }
 
 pub async fn user_login(payload: Json<UserLogin>, pool: Data<PgPool>) -> impl Responder {
@@ -92,11 +95,21 @@ pub async fn user_login(payload: Json<UserLogin>, pool: Data<PgPool>) -> impl Re
     };
     if is_valid {
         let token = generate_jwt_token(user_details.id).unwrap();
-        HttpResponse::Ok().json(ApiResponse {
-            status: 200,
-            msg: format!("User Loggedin !!"),
-            results: Some(token),
-        })
+        let cookie = Cookie::build("OKIJ", &token)
+            .http_only(true)
+            .same_site(SameSite::None)
+            .secure(true)
+            .path("/")
+            .max_age(Duration::hours(2))
+            .finish();
+
+        HttpResponse::Ok()
+            .cookie(cookie)
+            .json(ApiResponse::<String> {
+                status: 200,
+                msg: format!("User Loggedin !!"),
+                results: None,
+            })
     } else {
         HttpResponse::Unauthorized().json(ApiResponse::<String> {
             status: 401,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Authentication now uses a secure, HttpOnly cookie for sign-up and sign-in; tokens are no longer included in API responses.
  - Session cookie lasts 2 hours and is set with SameSite=None and Secure, enabling cross-site use while requiring HTTPS.
  - Unified behavior for both registration and login responses, simplifying session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->